### PR TITLE
Fixed crash on startup

### DIFF
--- a/lobster.example.cfg
+++ b/lobster.example.cfg
@@ -86,7 +86,7 @@ maximumIps = 1
 
 [database]
 ; MySQL database connection parameters
-host = localhost
+host = tcp(localhost:3306)
 username = lobster
 password =
 name = lobster


### PR DESCRIPTION
When compiled on Windows, the default database settings cause a crash at startup. The error is kinda cryptic, but it is caused by go-sql-driver. The hostname for mysql in the config should be specified using the following notation:
tcp(localhost:5555)

Check this for reference: http://stackoverflow.com/questions/25244089/go-error-connecting-to-database-with-mysqldriver

![lobster](https://cloud.githubusercontent.com/assets/9940084/16356996/6201f0da-3b1c-11e6-8f21-e00b5408facd.png)
